### PR TITLE
Solves namespace conflicts in Flutter 3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 .flutter-plugins-dependencies
 .flutter-plugins
 pubspec.lock
+.idea

--- a/bitsdojo_window_linux/lib/src/window.dart
+++ b/bitsdojo_window_linux/lib/src/window.dart
@@ -1,5 +1,5 @@
 import 'dart:ffi';
-import 'dart:ui';
+import 'dart:ui' as ui;
 import 'package:flutter/painting.dart';
 
 import 'package:ffi/ffi.dart';
@@ -35,8 +35,8 @@ Rect getScreenRectForWindow(int handle) {
 
 class GtkWindow extends DesktopWindow {
   int? handle;
-  Size? _minSize;
-  Size? _maxSize;
+  ui.Size? _minSize;
+  ui.Size? _maxSize;
   Alignment? _alignment;
   // size and position are cached during doWhenWindowReady
   // because the window operations for setting size/position
@@ -89,8 +89,8 @@ class GtkWindow extends DesktopWindow {
   }
 
   @override
-  Size get size {
-    if (!isValidHandle(handle, "get size")) return Size.zero;
+  ui.Size get size {
+    if (!isValidHandle(handle, "get size")) return ui.Size.zero;
 
     if (isInsideDoWhenWindowReady == true && _cached.rect != null) {
       return _cached.rect!.size;
@@ -99,19 +99,19 @@ class GtkWindow extends DesktopWindow {
     Pointer<Int32> nativeResult = malloc.allocate(sizeOf<Int32>() * 2);
     native.getSize(
         handle!, nativeResult.elementAt(0), nativeResult.elementAt(1));
-    Size result = Size(nativeResult[0].toDouble(), nativeResult[1].toDouble());
+    ui.Size result = ui.Size(nativeResult[0].toDouble(), nativeResult[1].toDouble());
     malloc.free(nativeResult);
     final gotSize = getLogicalSize(result);
     return gotSize;
   }
 
-  Size get sizeOnScreen {
+  ui.Size get sizeOnScreen {
     if (isInsideDoWhenWindowReady == true && _cached.rect != null) {
       final sizeOnScreen = getSizeOnScreen(_cached.rect!.size);
       return sizeOnScreen;
     }
     final winRect = this.rect;
-    return Size(winRect.width, winRect.height);
+    return ui.Size(winRect.width, winRect.height);
   }
 
   @override
@@ -140,24 +140,24 @@ class GtkWindow extends DesktopWindow {
   }
 
   @override
-  Size get titleBarButtonSize {
+  ui.Size get titleBarButtonSize {
     // NOTE: This might be difficult to retrieve from gtk
-    Size result = Size(32, 32);
+    ui.Size result = ui.Size(32, 32);
     return result;
   }
 
-  Size getSizeOnScreen(Size inSize) {
+  ui.Size getSizeOnScreen(ui.Size inSize) {
     double scaleFactor = this.scaleFactor;
     double newWidth = inSize.width * scaleFactor;
     double newHeight = inSize.height * scaleFactor;
-    return Size(newWidth, newHeight);
+    return ui.Size(newWidth, newHeight);
   }
 
-  Size getLogicalSize(Size inSize) {
+  ui.Size getLogicalSize(ui.Size inSize) {
     double scaleFactor = this.scaleFactor;
     double newWidth = inSize.width / scaleFactor;
     double newHeight = inSize.height / scaleFactor;
-    return Size(newWidth, newHeight);
+    return ui.Size(newWidth, newHeight);
   }
 
   @override
@@ -176,7 +176,7 @@ class GtkWindow extends DesktopWindow {
   }
 
   @override
-  set minSize(Size? newSize) {
+  set minSize(ui.Size? newSize) {
     if (!isValidHandle(handle, "set minSize")) return;
 
     _minSize = newSize;
@@ -189,7 +189,7 @@ class GtkWindow extends DesktopWindow {
   }
 
   @override
-  set maxSize(Size? newSize) {
+  set maxSize(ui.Size? newSize) {
     if (!isValidHandle(handle, "set maxSize")) return;
 
     _maxSize = newSize;
@@ -202,7 +202,7 @@ class GtkWindow extends DesktopWindow {
   }
 
   @override
-  set size(Size newSize) {
+  set size(ui.Size newSize) {
     if (!isValidHandle(handle, "set size")) return;
 
     var width = newSize.width;
@@ -225,7 +225,7 @@ class GtkWindow extends DesktopWindow {
       if (newSize.height > _maxSize!.height) height = _maxSize!.height;
     }
 
-    Size sizeToSet = Size(width, height);
+    ui.Size sizeToSet = ui.Size(width, height);
 
     // Save cached rect
     final double left = _cached.rect != null ? _cached.rect!.left : 0;

--- a/bitsdojo_window_windows/lib/src/window.dart
+++ b/bitsdojo_window_windows/lib/src/window.dart
@@ -1,5 +1,5 @@
 import 'dart:ffi';
-import 'dart:ui';
+import 'dart:ui' as ui;
 import 'package:flutter/painting.dart';
 
 import 'package:ffi/ffi.dart';
@@ -37,11 +37,11 @@ Rect getScreenRectForWindow(int handle) {
 
 class WinWindow extends WinDesktopWindow {
   int? handle;
-  Size? _minSize;
-  Size? _maxSize;
+  ui.Size? _minSize;
+  ui.Size? _maxSize;
   // We use this for reporting size inside doWhenWindowReady
   // as GetWindowRect might not work reliably before window is shown on screen
-  Size? _sizeSetFromDart;
+  ui.Size? _sizeSetFromDart;
   Alignment? _alignment;
 
   void setWindowCutOnMaximize(int value) {
@@ -67,13 +67,13 @@ class WinWindow extends WinDesktopWindow {
         newRect.width.toInt(), newRect.height.toInt(), 0);
   }
 
-  Size get size {
+  ui.Size get size {
     final winRect = this.rect;
-    final gotSize = getLogicalSize(Size(winRect.width, winRect.height));
+    final gotSize = getLogicalSize(ui.Size(winRect.width, winRect.height));
     return gotSize;
   }
 
-  Size get sizeOnScreen {
+  ui.Size get sizeOnScreen {
     if (isInsideDoWhenWindowReady == true) {
       if (_sizeSetFromDart != null) {
         final sizeOnScreen = getSizeOnScreen(_sizeSetFromDart!);
@@ -81,7 +81,7 @@ class WinWindow extends WinDesktopWindow {
       }
     }
     final winRect = this.rect;
-    return Size(winRect.width, winRect.height);
+    return ui.Size(winRect.width, winRect.height);
   }
 
   double systemMetric(int metric, {int dpiToUse = 0}) {
@@ -117,27 +117,27 @@ class WinWindow extends WinDesktopWindow {
     return result;
   }
 
-  Size get titleBarButtonSize {
+  ui.Size get titleBarButtonSize {
     double height = this.titleBarHeight - this.borderSize;
     double scaleFactor = this.scaleFactor;
     double cyCaption = systemMetric(SM_CYCAPTION);
     cyCaption /= scaleFactor;
     double width = cyCaption * 2;
-    return Size(width, height);
+    return ui.Size(width, height);
   }
 
-  Size getSizeOnScreen(Size inSize) {
+  ui.Size getSizeOnScreen(ui.Size inSize) {
     double scaleFactor = this.scaleFactor;
     double newWidth = inSize.width * scaleFactor;
     double newHeight = inSize.height * scaleFactor;
-    return Size(newWidth, newHeight);
+    return ui.Size(newWidth, newHeight);
   }
 
-  Size getLogicalSize(Size inSize) {
+  ui.Size getLogicalSize(ui.Size inSize) {
     double scaleFactor = this.scaleFactor;
     double newWidth = inSize.width / scaleFactor;
     double newHeight = inSize.height / scaleFactor;
-    return Size(newWidth, newHeight);
+    return ui.Size(newWidth, newHeight);
   }
 
   Alignment? get alignment => _alignment;
@@ -155,7 +155,7 @@ class WinWindow extends WinDesktopWindow {
     }
   }
 
-  set minSize(Size? newSize) {
+  set minSize(ui.Size? newSize) {
     _minSize = newSize;
     if (newSize == null) {
       //TODO - add handling for setting minSize to null
@@ -164,7 +164,7 @@ class WinWindow extends WinDesktopWindow {
     native.setMinSize(_minSize!.width.toInt(), _minSize!.height.toInt());
   }
 
-  set maxSize(Size? newSize) {
+  set maxSize(ui.Size? newSize) {
     _maxSize = newSize;
     if (newSize == null) {
       //TODO - add handling for setting maxSize to null
@@ -173,7 +173,7 @@ class WinWindow extends WinDesktopWindow {
     native.setMaxSize(_maxSize!.width.toInt(), _maxSize!.height.toInt());
   }
 
-  set size(Size newSize) {
+  set size(ui.Size newSize) {
     if (!isValidHandle(handle, "set size")) return;
 
     var width = newSize.width;
@@ -196,7 +196,7 @@ class WinWindow extends WinDesktopWindow {
       if (newSize.height > _maxSize!.height) height = _maxSize!.height;
     }
 
-    Size sizeToSet = Size(width, height);
+    ui.Size sizeToSet = ui.Size(width, height);
     _sizeSetFromDart = sizeToSet;
     if (_alignment == null) {
       SetWindowPos(handle!, 0, 0, 0, sizeToSet.width.toInt(),


### PR DESCRIPTION
In Flutter 3, but ffi and ui package has the class Size so we have to
let a prefix to let compiler to know the Size class that we use is from
the ui package.